### PR TITLE
fix: add ModelId and MaxTokens to ConversationRequest for LLM stability

### DIFF
--- a/cli/prompting.go
+++ b/cli/prompting.go
@@ -121,6 +121,8 @@ func makeDiscoverQuery(params DiscoverQueryParams, prompt string) (DiscoverQuery
 				},
 			},
 		},
+		ModelId:   params.Model,
+		MaxTokens: params.MaxTokens,
 	}
 
 	llmResponse, err := provider.Chat(context.Background(), request)


### PR DESCRIPTION
- Added `ModelId` to `providers.ConversationRequest` to ensure the correct model is used.
- Included `MaxTokens` to prevent exceeding token limits, avoiding potential API errors.

This fix prevents unexpected errors and ensures compatibility with the OpenAI API.

## Contributor Agreement

By submitting this pull request, I affirm that:

- [ ] I have reviewed, fully understand, and agree to abide by the terms of the Contributor License Agreement detailed in [CONTRIBUTING.md](/CONTRIBUTING.md).
