### PR TITLE
Fix missing tool descriptions

### DIFF
--- a/mcpgenerator/server_tools.go
+++ b/mcpgenerator/server_tools.go
@@ -22,6 +22,11 @@ func (s *MCPServer) SetTools(tools []model.Endpoint) {
 	s.server.DeleteTools(names...)
 	for _, endpoint := range tools {
 		var opts []mcp.ToolOption
+		if endpoint.Description != "" {
+			opts = append(opts, mcp.WithDescription(endpoint.Description))
+		} else if endpoint.Summary != "" {
+			opts = append(opts, mcp.WithDescription(endpoint.Summary))
+		}
 		for _, col := range endpoint.Params {
 			if col.Required {
 				opts = append(opts, ArgumentOption(col, mcp.Required()))

--- a/mcpgenerator/server_tools_test.go
+++ b/mcpgenerator/server_tools_test.go
@@ -1,0 +1,37 @@
+package mcpgenerator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/centralmind/gateway/mcp"
+	"github.com/centralmind/gateway/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetToolsIncludesDescription(t *testing.T) {
+	srv, err := New(nil)
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	// initialize server to enable tools capabilities
+	_ = srv.Server().HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`))
+
+	endpoint := model.Endpoint{
+		MCPMethod:   "test_method",
+		Description: "sample description",
+		Params: []model.EndpointParams{
+			{Name: "id", Type: "string"},
+		},
+	}
+
+	srv.SetTools([]model.Endpoint{endpoint})
+
+	resp := srv.Server().HandleMessage(ctx, []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`))
+	listResp, ok := resp.(mcp.JSONRPCResponse)
+	assert.True(t, ok)
+	tools := listResp.Result.(mcp.ListToolsResult).Tools
+	if assert.Len(t, tools, 1) {
+		assert.Equal(t, "sample description", tools[0].Description)
+	}
+}


### PR DESCRIPTION

The repository lacked custom tool descriptions when configuring endpoints via YAML. The issue was traced to mcpgenerator/server_tools.go, where descriptions weren’t passed to mcp.NewTool. A new test ensures descriptions are preserved. Tests fail due to module download restrictions in the environment.

Summary

Added logic to include a tool’s description (or summary) when registering tools from YAML

Created TestSetToolsIncludesDescription verifying that tool descriptions appear in the MCP tools list output


## Contributor Agreement

By submitting this pull request, I affirm that:

- [x ] I have reviewed, fully understand, and agree to abide by the terms of the Contributor License Agreement detailed in [CONTRIBUTING.md](/CONTRIBUTING.md).
