### PR TITLE
bugfix: skip omitempty at tools[].inputSchema.properties

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -105,7 +105,7 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 
 type ToolInputSchema struct {
 	Type       string                 `json:"type"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
+	Properties map[string]interface{} `json:"properties"`
 	Required   []string               `json:"required,omitempty"`
 }
 

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -142,3 +142,24 @@ func TestUnmarshalToolWithoutRawSchema(t *testing.T) {
 	assert.Empty(t, toolUnmarshalled.InputSchema.Required)
 	assert.Empty(t, toolUnmarshalled.RawInputSchema)
 }
+
+func TestMarshalToolWithoutInputSchemaProperties(t *testing.T) {
+	tool := NewTool("empty-input-schema-tool",
+		WithDescription("A tool with no input schema properties"),
+	)
+
+	data, err := json.Marshal(tool)
+	assert.Nil(t, err)
+
+	expected := json.RawMessage(`{
+  "description": "A tool with no input schema properties",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  },
+  "name": "empty-input-schema-tool"
+}
+`)
+
+	assert.JSONEq(t, string(expected), string(data))
+}


### PR DESCRIPTION
## Description

The `inputSchema.properties` is a required property according to https://modelcontextprotocol.io/docs/concepts/tools#implementing-tools

Fixes #85 

---
#### Contributor Agreement

By submitting this pull request, I affirm that:

- [x] I have reviewed, fully understand, and agree to abide by the terms of the Contributor License Agreement detailed in [CONTRIBUTING.md](/CONTRIBUTING.md).
